### PR TITLE
Use `gcloud app` instead of `gcloud preview app`

### DIFF
--- a/clients/firebase-android/README.md
+++ b/clients/firebase-android/README.md
@@ -122,7 +122,7 @@ Instructions vary depending on what programming language you are using.  For
 example, the [Node.js Bookstore example](/examples/nodejs/bookstore) backend is
 deployed using the `gcloud deploy` command:
 
-    gcloud --project=YOUR_PROJECT_ID preview app deploy app.yaml
+    gcloud --project=YOUR_PROJECT_ID app deploy app.yaml
 
 ## Call your backend from an Android client
 

--- a/clients/firebase-ios/README.md
+++ b/clients/firebase-ios/README.md
@@ -112,7 +112,7 @@ Instructions vary depending on what programming language you are using.  For
 example, the [Node.js Bookstore example](/examples/nodejs/bookstore) backend is
 deployed using the `gcloud deploy` command:
 
-    gcloud --project=YOUR_PROJECT_ID preview app deploy app.yaml
+    gcloud --project=YOUR_PROJECT_ID app deploy app.yaml
 
 ## Call your backend from an iOS client
 

--- a/clients/firebase-js/README.md
+++ b/clients/firebase-js/README.md
@@ -70,7 +70,7 @@ Instructions vary depending on what programming language you are using.  For
 example, the [Node.js Bookstore example](/examples/nodejs/bookstore) backend is
 deployed using the `gcloud deploy` command:
 
-    gcloud --project=YOUR_PROJECT_ID preview app deploy app.yaml
+    gcloud --project=YOUR_PROJECT_ID app deploy app.yaml
 
 ## Call your backend from Javascript client
 


### PR DESCRIPTION
We should use `gcloud app` instead of `gcloud preview app` which will go away soon.