### PR TITLE
Use gcloud beta app deploy for Endpoints

### DIFF
--- a/clients/firebase-android/README.md
+++ b/clients/firebase-android/README.md
@@ -122,7 +122,7 @@ Instructions vary depending on what programming language you are using.  For
 example, the [Node.js Bookstore example](/examples/nodejs/bookstore) backend is
 deployed using the `gcloud deploy` command:
 
-    gcloud --project=YOUR_PROJECT_ID app deploy
+    gcloud --project=YOUR_PROJECT_ID beta app deploy
 
 ## Call your backend from an Android client
 

--- a/clients/firebase-ios/README.md
+++ b/clients/firebase-ios/README.md
@@ -112,7 +112,7 @@ Instructions vary depending on what programming language you are using.  For
 example, the [Node.js Bookstore example](/examples/nodejs/bookstore) backend is
 deployed using the `gcloud deploy` command:
 
-    gcloud --project=YOUR_PROJECT_ID app deploy
+    gcloud --project=YOUR_PROJECT_ID beta app deploy
 
 ## Call your backend from an iOS client
 

--- a/clients/firebase-js/README.md
+++ b/clients/firebase-js/README.md
@@ -70,7 +70,7 @@ Instructions vary depending on what programming language you are using.  For
 example, the [Node.js Bookstore example](/examples/nodejs/bookstore) backend is
 deployed using the `gcloud deploy` command:
 
-    gcloud --project=YOUR_PROJECT_ID app deploy
+    gcloud --project=YOUR_PROJECT_ID beta app deploy
 
 ## Call your backend from Javascript client
 

--- a/clients/google-js/README.md
+++ b/clients/google-js/README.md
@@ -65,7 +65,7 @@ Deploy the backend. Instructions may vary depending on what programming language
 you are using. For example, with Node.js Bookstore example backend, update
 `host` property in the Swagger spec file, and run the `gcloud deploy` command:
 
-    gcloud --project=YOUR_PROJECT_ID app deploy
+    gcloud --project=YOUR_PROJECT_ID beta app deploy
 
 ## Running
 


### PR DESCRIPTION
Endpoints applications require use of "gcloud beta app deploy" to be deployed correctly.