### PR TITLE
Fix service.json location in nginx.conf

### DIFF
--- a/k8s/nginx.conf
+++ b/k8s/nginx.conf
@@ -14,11 +14,12 @@
 
 daemon off;
 
-user nobody nogroup;
+user nginx nginx;
 
 worker_processes 1;
 
-error_log  /var/log/nginx/error.log error;
+# Logging to stderr enables better integration with Docker and GKE/Kubernetes.
+error_log stderr warn;
 
 events { worker_connections 4096; }
 
@@ -29,6 +30,7 @@ http {
 
   upstream app_server {
     server localhost:8081;
+    keepalive 128;
   }
 
   endpoints {
@@ -44,13 +46,14 @@ http {
     ssl_certificate /etc/nginx/ssl/nginx.crt;
     ssl_certificate_key /etc/nginx/ssl/nginx.key;
 
-    access_log /var/log/nginx/access.log;
-
+    # Logging to stdout enables better integration with Docker and GKE/Kubernetes.
+    access_log /dev/stdout;
+    
     location / {
       # Begin Endpoints v2 Support
       endpoints {
         on;
-        api /app/endpoints/service.json;
+        api /etc/nginx/endpoints/service.json;
       }
       # End Endpoints v2 Support
 


### PR DESCRIPTION
Because of incorrect service.json location, it's not possible to successfully create pod using esp_echo_custom_config_gke.yaml (see "Use your custom nginx.conf" section)

Logging parameters in nginx.conf also have been synced with similar settings found in b.gcr.io/endpoints/endpoints-runtime:0.3 container

