### PR TITLE
Update esp_echo_http.yaml to use args

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -79,9 +79,7 @@ the values returned when you deployed the API:
    ```
    containers:
      - name: esp
-       image: b.gcr.io/endpoints/endpoints-runtime:0.3
-       command: [
-         "/usr/sbin/start_esp.py",
+       args: [
          "-p", "8080",            # the port ESP listens on
          "-a", "127.0.0.1:8081",  # the backend address
          "-s", "SERVICE_NAME",
@@ -93,7 +91,7 @@ the values returned when you deployed the API:
    Note you also need to change the service type from LoadBalancer to NodePort
    if you use [MiniKube](http://kubernetes.io/docs/getting-started-guides/minikube/)
 
-2. (Not necessary if you kubernetes cluster is on [GKE](https://cloud.google.com/container-engine/))
+2. (Not necessary if your kubernetes cluster is on [GKE](https://cloud.google.com/container-engine/)
    Create your service account credentials
 
 

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -79,6 +79,7 @@ the values returned when you deployed the API:
    ```
    containers:
      - name: esp
+       image: b.gcr.io/endpoints/endpoints-runtime:0.3
        args: [
          "-p", "8080",            # the port ESP listens on
          "-a", "127.0.0.1:8081",  # the backend address

--- a/k8s/esp_echo_http.yaml
+++ b/k8s/esp_echo_http.yaml
@@ -45,8 +45,7 @@ spec:
       containers:
         - name: esp
           image: b.gcr.io/endpoints/endpoints-runtime:0.3
-          command: [
-            "/usr/sbin/start_esp.py",
+          args: [
             "-p", "8080",
             "-a", "127.0.0.1:8081",
             "-s", "SERVICE_NAME",


### PR DESCRIPTION
- the latest esp docker image release has combined start_esp.py
  with old start up script, no need to use 'command' anymore.
- minor fix on README.md

@elibixby 