### PR TITLE
Update openapi.yaml

### DIFF
--- a/k8s/openapi.yaml
+++ b/k8s/openapi.yaml
@@ -4,7 +4,7 @@ info:
   description: "A simple Google Cloud Endpoints API example."
   title: "Endpoints Example"
   version: "1.0.0"
-host: "YOUR-PROJECT-ID.appspot.com"
+host: "echo-api.endpoints.YOUR-PROJECT-ID.cloud.goog"
 # [END add_project]
 basePath: "/"
 consumes:


### PR DESCRIPTION
To be consistent with the other samples and docs, the host name should be: "echo-api.endpoints.YOUR-PROJECT-ID.cloud.goog"