### PR TITLE
Add an example Nginx config file for GKE

### DIFF
--- a/k8s/nginx_gke_example_1.conf
+++ b/k8s/nginx_gke_example_1.conf
@@ -1,0 +1,99 @@
+# Copyright 2017 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This nginx config is a simplified example from the master template at
+# https://github.com/cloudendpoints/endpoints-tools/blob/master/start_esp/nginx-auto.conf.template
+# Please always refer to the master template for any latest updates.
+
+daemon off;
+
+user nginx nginx;
+
+worker_processes 1;
+
+# Logging to stderr enables better integration with Docker and GKE/Kubernetes.
+error_log stderr warn;
+
+events { worker_connections 4096; }
+
+http {
+  include /etc/nginx/mime.types;
+  server_tokens off;
+  client_max_body_size 32m;
+
+  upstream app_server {
+    server localhost:8080;
+    keepalive 128;
+  }
+
+  endpoints {
+    metadata_server;
+  }
+
+  server {
+    # Running port
+    listen 8081;
+
+    # Logging to stdout enables better integration with Docker and GKE/Kubernetes.
+    access_log /dev/stdout;
+    
+    location / {
+      # Begin Endpoints v2 Support
+      endpoints {
+        on;
+        # After ESP 1.7.0, "server_config" field is required.
+        # It has to be /etc/nginx/server_config.pb.txt exactly.
+        # If not present, some new features will not work.
+        server_config /etc/nginx/server_config.pb.txt;
+
+        # After ESP 1.7.0, "api" field is not required.
+        # If added, it has to be /etc/nginx/endpoints/service.json exactly.
+        # api /etc/nginx/endpoints/service.json;
+
+        # Uncomment the line below if you are not using Google Container Engine.
+        # The path should be set to the “-k” path specified in the ESP container’s                 
+        # args section in the Kubernetes yaml config.
+        # google_authentication_secret /etc/nginx/creds/service-account-creds.json;
+      }
+      # End Endpoints v2 Support
+
+      proxy_pass http://app_server;
+      proxy_redirect off;
+      proxy_set_header Host $host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Host $server_name;
+      proxy_set_header X-Google-Real-IP $remote_addr;
+
+      # 86400 seconds (24 hours) is the maximum a server is allowed.
+      proxy_send_timeout 86400s;
+      proxy_read_timeout 86400s;
+    }
+
+    include /var/lib/nginx/extra/*.conf;
+  }
+
+  server {
+    # expose /nginx_status but on a different port to avoid
+    # external visibility / conflicts with the app.
+    listen 8090;
+    location /nginx_status {
+      stub_status on;
+      access_log off;
+    }
+    location / {
+      root /dev/null;
+    }
+  }
+}


### PR DESCRIPTION
Add an example Nginx config file for GKE, which is used in a
step-by-step guide for configuring CORS on Cloud Endpoints Nginx For GKE.