### PR TITLE
[DO NOT MERGE] Change to endpoints managed rollout

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -72,8 +72,7 @@ To deploy to the cluster:
 
 1. Edit the Kubernetes configuration file,
 i.e. [esp_echo_http.yaml](esp_echo_http.yaml),
-replacing `SERVICE_NAME` and `SERVICE_CONFIG_ID` shown in the snippet below with
-the values returned when you deployed the API:
+replacing `SERVICE_NAME` shown in the snippet below with the value returned when you deployed the API:
 
    ```
    containers:
@@ -83,7 +82,7 @@ the values returned when you deployed the API:
          "-p", "8080",            # the port ESP listens on
          "-a", "127.0.0.1:8081",  # the backend address
          "-s", "SERVICE_NAME",
-         "-v", "SERVICE_CONFIG_ID",
+         "--rollout_strategy", "managed",
          "-k", "/etc/nginx/creds/service-account-creds.json",  # not needed for GKE
        ]
    ```

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -63,8 +63,7 @@ To deploy the sample application:
 
    Note that the configuration ID that is displayed will change when you deploy a new version of the API.
 
-2. Make a note of the service name and the service configuration ID because you'll need
-them later when you configure the container cluster for the API.
+2. Make a note of the service name because you'll need it later when you configure the container cluster for the API.
 
 ## Deploying the sample API to the cluster
 

--- a/k8s/esp_echo_custom_config_gke.yaml
+++ b/k8s/esp_echo_custom_config_gke.yaml
@@ -53,7 +53,7 @@ spec:
         args: [
           "-n", "/etc/nginx/custom/nginx.conf",
           "-s", "SERVICE_NAME",
-          "-v", "SERVICE_CONFIG_ID",
+          "--rollout_strategy", "managed",
         ]
         ports:
           - containerPort: 8080

--- a/k8s/esp_echo_gke.yaml
+++ b/k8s/esp_echo_gke.yaml
@@ -53,7 +53,7 @@ spec:
           "--ssl_port", "443",
           "--backend", "127.0.0.1:8081",
           "--service", "SERVICE_NAME",
-          "--version", "SERVICE_CONFIG_ID",
+          "--rollout_strategy", "managed",
         ]
         ports:
           - containerPort: 8080

--- a/k8s/esp_echo_gke_ingress.yaml
+++ b/k8s/esp_echo_gke_ingress.yaml
@@ -45,7 +45,7 @@ spec:
           "-p", "8080",
           "-a", "127.0.0.1:8081",
           "-s", "SERVICE_NAME",
-          "-v", "SERVICE_CONFIG_ID",
+          "--rollout_strategy", "managed",
           "-z", "healthz",
         ]
         readinessProbe:

--- a/k8s/esp_echo_http.yaml
+++ b/k8s/esp_echo_http.yaml
@@ -52,7 +52,7 @@ spec:
             "--http_port", "8080",
             "--backend", "127.0.0.1:8081",
             "--service", "SERVICE_NAME",
-            "--version", "SERVICE_CONFIG_ID",
+            "--rollout_strategy", "managed",
             "--service_account_key", "/etc/nginx/creds/service-account-creds.json",
           ]
       # [END service]

--- a/k8s/esp_echo_http_gke.yaml
+++ b/k8s/esp_echo_http_gke.yaml
@@ -44,7 +44,7 @@ spec:
           "-p", "8080",
           "-a", "127.0.0.1:8081",
           "-s", "SERVICE_NAME",
-          "-v", "SERVICE_CONFIG_ID",
+          "--rollout_strategy", "managed",
         ]
         ports:
           - containerPort: 8080


### PR DESCRIPTION
We introduce a new feature where we can specify in YAML that service configuration for Endpoints is going to be managed. This means that the service will pull latest deployed service configuration automatically, rather than requiring customer to specify specific version of service configuration.

New flag:
**--rollout_strategy=managed**
Previously the only way to specify a version was using the following flag:
**--version=SERVICE_CONFIG_ID**