### PR TITLE
Updated the gcloud command

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -52,7 +52,7 @@ To deploy the sample application:
 1. Invoke the following command:
 
    ```
-   gcloud service-management deploy openapi.yaml
+   gcloud endpoints services deploy openapi.yaml
    ```
 
    The command returns several lines of information, including a line similar to the following:


### PR DESCRIPTION
The command to deploy the service configuration: `gcloud service-management  deploy` no longer exists. The new command is:
`gcloud endpoints services deploy'