### PR TITLE
Modify all the languages of GKE deployment to use Ingress LB and service in order to setup container native LB.

### DIFF
--- a/getting-started/golang-deployment.yaml
+++ b/getting-started/golang-deployment.yaml
@@ -12,10 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: esp-echo
+spec:
+  backend:
+    serviceName: esp-echo # Name of the Service targeted by the Ingress
+    servicePort: 80 # Should match the port used by the Service
+---
 apiVersion: v1
 kind: Service
 metadata:
   name: esp-echo
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
 spec:
   ports:
   - port: 80
@@ -24,7 +35,7 @@ spec:
     name: http
   selector:
     app: esp-echo
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -49,7 +60,12 @@ spec:
           "--backend", "127.0.0.1:8080",
           "--service", "SERVICE_NAME",
           "--rollout_strategy", "managed",
+          "--healthz=/healthz",
         ]
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
       # [END esp]
         ports:
           - containerPort: 8081

--- a/getting-started/grpc-deployment.yaml
+++ b/getting-started/grpc-deployment.yaml
@@ -12,10 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: grpc-hello
+spec:
+  backend:
+    serviceName: grpc-hello # Name of the Service targeted by the Ingress
+    servicePort: 80 # Should match the port used by the Service
+---
 apiVersion: v1
 kind: Service
 metadata:
   name: grpc-hello
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
 spec:
   ports:
   - port: 80
@@ -24,7 +35,7 @@ spec:
     name: http
   selector:
     app: grpc-hello
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -48,7 +59,12 @@ spec:
           "--backend=grpc://127.0.0.1:50051",
           "--service=SERVICE_NAME",
           "--rollout_strategy=managed",
+          "--healthz=/healthz",
         ]
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 9000
         ports:
           - containerPort: 9000
       - name: python-grpc-hello

--- a/getting-started/java-deployment.yaml
+++ b/getting-started/java-deployment.yaml
@@ -12,10 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: esp-echo
+spec:
+  backend:
+    serviceName: esp-echo # Name of the Service targeted by the Ingress
+    servicePort: 80 # Should match the port used by the Service
+---
 apiVersion: v1
 kind: Service
 metadata:
   name: esp-echo
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
 spec:
   ports:
   - port: 80
@@ -24,7 +35,7 @@ spec:
     name: http
   selector:
     app: esp-echo
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -49,7 +60,12 @@ spec:
           "--backend=127.0.0.1:8080",
           "--service=SERVICE_NAME",
           "--rollout_strategy=managed",
+          "--healthz=/healthz",
         ]
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
       # [END esp]
         ports:
           - containerPort: 8081

--- a/getting-started/nodejs-deployment.yaml
+++ b/getting-started/nodejs-deployment.yaml
@@ -11,11 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: esp-echo
+spec:
+  backend:
+    serviceName: esp-echo # Name of the Service targeted by the Ingress
+    servicePort: 80 # Should match the port used by the Service
+---
 apiVersion: v1
 kind: Service
 metadata:
   name: esp-echo
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
 spec:
   ports:
   - port: 80
@@ -24,7 +34,7 @@ spec:
     name: http
   selector:
     app: esp-echo
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -49,7 +59,12 @@ spec:
           "--backend", "127.0.0.1:8080",
           "--service", "SERVICE_NAME",
           "--rollout_strategy", "managed",
+          "--healthz=/healthz",
         ]
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
       # [END esp]
         ports:
           - containerPort: 8081

--- a/getting-started/php-deployment.yaml
+++ b/getting-started/php-deployment.yaml
@@ -12,10 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: esp-echo
+spec:
+  backend:
+    serviceName: esp-echo # Name of the Service targeted by the Ingress
+    servicePort: 80 # Should match the port used by the Service
+---
 apiVersion: v1
 kind: Service
 metadata:
   name: esp-echo
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
 spec:
   ports:
   - port: 80
@@ -24,7 +35,7 @@ spec:
     name: http
   selector:
     app: esp-echo
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -49,8 +60,13 @@ spec:
           "--backend", "127.0.0.1:8080",
           "--service", "SERVICE_NAME",
           "--rollout_strategy", "managed",
+          "--healthz=/healthz",
         ]
       # [END esp]
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
         ports:
           - containerPort: 8081
       - name: echo

--- a/getting-started/python-deployment.yaml
+++ b/getting-started/python-deployment.yaml
@@ -12,10 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: esp-echo
+spec:
+  backend:
+    serviceName: esp-echo # Name of the Service targeted by the Ingress
+    servicePort: 80 # Should match the port used by the Service
+---
 apiVersion: v1
 kind: Service
 metadata:
   name: esp-echo
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
 spec:
   ports:
   - port: 80
@@ -24,7 +35,7 @@ spec:
     name: http
   selector:
     app: esp-echo
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -49,7 +60,12 @@ spec:
           "--backend=http://127.0.0.1:8080",
           "--service=SERVICE_NAME",
           "--rollout_strategy=managed",
+          "--healthz=/healthz",
         ]
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
       # [END esp]
         ports:
         - containerPort: 8081

--- a/getting-started/ruby-deployment.yaml
+++ b/getting-started/ruby-deployment.yaml
@@ -12,10 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: esp-echo
+spec:
+  backend:
+    serviceName: esp-echo # Name of the Service targeted by the Ingress
+    servicePort: 80 # Should match the port used by the Service
+---
 apiVersion: v1
 kind: Service
 metadata:
   name: esp-echo
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
 spec:
   ports:
   - port: 80
@@ -24,7 +35,7 @@ spec:
     name: http
   selector:
     app: esp-echo
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -49,8 +60,13 @@ spec:
           "--backend", "127.0.0.1:8080",
           "--service", "SERVICE_NAME",
           "--rollout_strategy", "managed",
+          "--healthz=/healthz",
         ]
       # [END esp]
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
         ports:
           - containerPort: 8081
       - name: echo


### PR DESCRIPTION
Modify all the languages of GKE deployment to use Ingress LB and service in order to setup [container native LB](https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing).

This change may need to be submitted after we update the public doc to start an IP alias enabled cluster. There are some internal changes inside Google doc:

The internal change is we'll update the GCP tutorial [openapi/get-started-kubernetes-espv2](https://cloud.google.com/endpoints/docs/openapi/get-started-kubernetes-espv2) by
* Instruct to create an IP alias enabled cluster in [creating a container cluster section](https://cloud.google.com/endpoints/docs/openapi/get-started-kubernetes-engine-espv2#create_cluster)
* Instruct to get the external IP address of the endpoint from ingress instead of from [service](https://cloud.google.com/endpoints/docs/openapi/get-started-kubernetes-engine-espv2#get_ip)