### PR TITLE
Modify gke/grpc-bookstore.yaml to use GKE ingress for container native load balancing.

### DIFF
--- a/gke/grpc-bookstore.yaml
+++ b/gke/grpc-bookstore.yaml
@@ -30,7 +30,7 @@ spec:
     secretName: esp-ssl
   backend:
     serviceName: esp-grpc-bookstore
-    servicePort: 80
+    servicePort: 443
 ---
 apiVersion: cloud.google.com/v1
 kind: BackendConfig
@@ -48,12 +48,12 @@ metadata:
   name: esp-grpc-bookstore
   annotations:
     service.alpha.kubernetes.io/app-protocols: '{"esp-grpc-bookstore":"HTTP2"}'
-    cloud.google.com/neg: '{"ingress": true, "exposed_ports": {"80":{}}}'
+    cloud.google.com/neg: '{"ingress": true, "exposed_ports": {"443":{}}}'
     cloud.google.com/backend-config: '{"default": "esp-grpc-bookstore"}'
 spec:
   ports:
-  # Port that accepts gRPC and JSON/HTTP2 requests over HTTP.
-  - port: 80
+  # Port that accepts gRPC and JSON/HTTP2 requests over TLS.
+  - port: 443
     targetPort: 9000
     protocol: TCP
     name: esp-grpc-bookstore

--- a/gke/grpc-bookstore.yaml
+++ b/gke/grpc-bookstore.yaml
@@ -16,20 +16,50 @@
 # and the container for the Extensible Service Proxy (ESP) to
 # Google Kubernetes Engine (GKE).
 
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: esp-grpc-bookstore
+  annotations:
+    kubernetes.io/ingress.class: "gce"
+    kubernetes.io/ingress.allow-http: "false"
+spec:
+  tls:
+  - hosts:
+    - SERVICE_NAME
+    secretName: esp-ssl
+  backend:
+    serviceName: esp-grpc-bookstore
+    servicePort: 80
+---
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: esp-grpc-bookstore
+spec:
+  healthCheck:
+    type: HTTP2
+    requestPath: /healthz
+    port: 9000
+---
 apiVersion: v1
 kind: Service
 metadata:
   name: esp-grpc-bookstore
+  annotations:
+    service.alpha.kubernetes.io/app-protocols: '{"esp-grpc-bookstore":"HTTP2"}'
+    cloud.google.com/neg: '{"ingress": true, "exposed_ports": {"80":{}}}'
+    cloud.google.com/backend-config: '{"default": "esp-grpc-bookstore"}'
 spec:
   ports:
   # Port that accepts gRPC and JSON/HTTP2 requests over HTTP.
   - port: 80
     targetPort: 9000
     protocol: TCP
-    name: http2
+    name: esp-grpc-bookstore
   selector:
     app: esp-grpc-bookstore
-  type: LoadBalancer
+  type: ClusterIP
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -45,6 +75,10 @@ spec:
       labels:
         app: esp-grpc-bookstore
     spec:
+      volumes:
+      - name: esp-ssl
+        secret:
+          secretName: esp-ssl
       containers:
       - name: esp
         image: gcr.io/endpoints-release/endpoints-runtime:2
@@ -52,10 +86,16 @@ spec:
           "--listener_port=9000",
           "--service=SERVICE_NAME",
           "--rollout_strategy=managed",
-          "--backend=grpc://127.0.0.1:8000"
+          "--backend=grpc://127.0.0.1:8000",
+          "--healthz=/healthz",
+          "--ssl_server_cert_path=/etc/esp/ssl",
         ]
         ports:
           - containerPort: 9000
+        volumeMounts:
+        - mountPath: /etc/esp/ssl
+          name:  esp-ssl
+          readOnly: true
       - name: bookstore
         image: gcr.io/endpointsv2/python-grpc-bookstore-server:1
         ports:


### PR DESCRIPTION
## Modify gke/grpc-bookstore.yaml to use GKE ingress for container native load balancing.

These sample code is being used by https://cloud.google.com/endpoints/docs/grpc/get-started-kubernetes-engine-espv2. Changes in this PR include:

* TLS secret is attached to both ingress and ESPv2.
* Service type is changed from "LoadBalancer" to "ClusterIP" because
  ingress will start manage the external load balancer.

There are also a few Google internal docs changes pending:
* Users will create an IP alias enabled cluster in [creating a container cluster section](https://cloud.google.com/endpoints/docs/grpc/get-started-kubernetes-engine-espv2#creating_a_container_cluster).
* Users will configure TLS because container native LB uses HTTP2 and TLS is a must to have.
