### PR TITLE
Fix the unhealthy backend by adding backend config healthcheck. 

### DIFF
--- a/getting-started/golang-deployment.yaml
+++ b/getting-started/golang-deployment.yaml
@@ -27,6 +27,7 @@ metadata:
   name: esp-echo
   annotations:
     cloud.google.com/neg: '{"ingress": true}'
+    cloud.google.com/backend-config: '{"default": "esp-echo"}'
 spec:
   ports:
   - port: 80
@@ -36,6 +37,16 @@ spec:
   selector:
     app: esp-echo
   type: ClusterIP
+---
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: esp-echo
+spec:
+  healthCheck:
+    type: HTTP
+    requestPath: /healthz
+    port: 8081
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/getting-started/grpc-deployment.yaml
+++ b/getting-started/grpc-deployment.yaml
@@ -27,6 +27,7 @@ metadata:
   name: grpc-hello
   annotations:
     cloud.google.com/neg: '{"ingress": true}'
+    cloud.google.com/backend-config: '{"default": "esp-echo"}'
 spec:
   ports:
   - port: 80
@@ -36,6 +37,16 @@ spec:
   selector:
     app: grpc-hello
   type: ClusterIP
+---
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: esp-echo
+spec:
+  healthCheck:
+    type: HTTP
+    requestPath: /healthz
+    port: 9000
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/getting-started/java-deployment.yaml
+++ b/getting-started/java-deployment.yaml
@@ -27,6 +27,7 @@ metadata:
   name: esp-echo
   annotations:
     cloud.google.com/neg: '{"ingress": true}'
+    cloud.google.com/backend-config: '{"default": "esp-echo"}'
 spec:
   ports:
   - port: 80
@@ -36,6 +37,16 @@ spec:
   selector:
     app: esp-echo
   type: ClusterIP
+---
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: esp-echo
+spec:
+  healthCheck:
+    type: HTTP
+    requestPath: /healthz
+    port: 8081
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/getting-started/nodejs-deployment.yaml
+++ b/getting-started/nodejs-deployment.yaml
@@ -26,6 +26,7 @@ metadata:
   name: esp-echo
   annotations:
     cloud.google.com/neg: '{"ingress": true}'
+    cloud.google.com/backend-config: '{"default": "esp-echo"}'
 spec:
   ports:
   - port: 80
@@ -35,6 +36,16 @@ spec:
   selector:
     app: esp-echo
   type: ClusterIP
+---
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: esp-echo
+spec:
+  healthCheck:
+    type: HTTP
+    requestPath: /healthz
+    port: 8081
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/getting-started/php-deployment.yaml
+++ b/getting-started/php-deployment.yaml
@@ -27,6 +27,7 @@ metadata:
   name: esp-echo
   annotations:
     cloud.google.com/neg: '{"ingress": true}'
+    cloud.google.com/backend-config: '{"default": "esp-echo"}'
 spec:
   ports:
   - port: 80
@@ -36,6 +37,16 @@ spec:
   selector:
     app: esp-echo
   type: ClusterIP
+---
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: esp-echo
+spec:
+  healthCheck:
+    type: HTTP
+    requestPath: /healthz
+    port: 8081
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/getting-started/python-deployment.yaml
+++ b/getting-started/python-deployment.yaml
@@ -27,6 +27,7 @@ metadata:
   name: esp-echo
   annotations:
     cloud.google.com/neg: '{"ingress": true}'
+    cloud.google.com/backend-config: '{"default": "esp-echo"}'
 spec:
   ports:
   - port: 80
@@ -36,6 +37,15 @@ spec:
   selector:
     app: esp-echo
   type: ClusterIP
+---
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: esp-echo
+spec:
+  healthCheck:
+    type: HTTP
+    requestPath: /healthz
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/getting-started/ruby-deployment.yaml
+++ b/getting-started/ruby-deployment.yaml
@@ -27,6 +27,7 @@ metadata:
   name: esp-echo
   annotations:
     cloud.google.com/neg: '{"ingress": true}'
+    cloud.google.com/backend-config: '{"default": "esp-echo"}'
 spec:
   ports:
   - port: 80
@@ -36,6 +37,16 @@ spec:
   selector:
     app: esp-echo
   type: ClusterIP
+---
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: esp-echo
+spec:
+  healthCheck:
+    type: HTTP
+    requestPath: /healthz
+    port: 8081
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
This was caught in the internal bug http://b/184422201. 

> https://cloud.google.com/endpoints/docs/openapi/get-started-kubernetes-engine-espv2?hl=en

>Trying this on autopilot running 1.18.16-gke.302, the deployment end up with a broken load balancer with unhealthy backend.
> After some investigation, this is because the health check configured is sending an HTTP GET / - that returns "404 - The current request is not defined by this API" - as configured.

>To fix it you have to modify the health check to send HTTP GET /healthz A possible fix is to add a backend config to the manifest.