### PR TITLE
Update URLs

### DIFF
--- a/gce/README.md
+++ b/gce/README.md
@@ -25,7 +25,7 @@ This repository provides a template and instructions for setting up an API scala
 
 ### Step 2: Upload a startup script and (optionally) a nginx config.
 
-This repository provides an example [startup.sh](./startup.sh) script that installs the Extensible Service Proxy (ESP) directly on your GCE instance. This particular startup script installs the example API provided in [python-docs-samples](https://github.com/GoogleCloudPlatform/python-docs-samples/tree/master/managed_vms/endpoints). However, by replacing the code between the comments you can repurpose this script for your own API. After you have done this, upload it to a cloud storage bucket in your project, and note the path.
+This repository provides an example [startup.sh](./startup.sh) script that installs the Extensible Service Proxy (ESP) directly on your GCE instance. This particular startup script installs the example API provided in [python-docs-samples](https://github.com/GoogleCloudPlatform/python-docs-samples/tree/main/endpoints/getting-started). However, by replacing the code between the comments you can repurpose this script for your own API. After you have done this, upload it to a cloud storage bucket in your project, and note the path.
 
 If you want to customize the configuration of the ESP, you can also upload an `nginx.conf` file to the Cloud Storage
 

--- a/gce/startup.sh
+++ b/gce/startup.sh
@@ -42,7 +42,7 @@ sudo apt-get install -y  build-essential libssl-dev libffi-dev python-dev git py
 
 git clone https://github.com/GoogleCloudPlatform/python-docs-samples
 
-cd python-docs-samples/appengine/flexible/endpoints
+cd python-docs-samples/endpoints/getting-started
 virtualenv env
 source env/bin/activate
 pip install -r requirements.txt

--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -2,9 +2,9 @@
 These ESPv2 GKE(Google Kubernetes Engine) deployment files are used in Cloud Endpoints public [documents](https://cloud.google.com/endpoints/docs/openapi/tutorials).
 
 They are for the `getting-started` echo samples in following github repositories:
-* [Python](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/master/endpoints/getting-started) getting-started echo sample.
-* [Java](https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/endpoints/getting-started) getting-started echo sample.
-* [Golang](https://github.com/GoogleCloudPlatform/golang-docs-samples/blob/master/endpoints/getting-started) getting-started echo sample.
+* [Python](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/endpoints/getting-started) getting-started echo sample.
+* [Java](https://github.com/GoogleCloudPlatform/java-docs-samples/tree/main/endpoints/getting-started) getting-started echo sample.
+* [Golang](https://github.com/GoogleCloudPlatform/golang-samples/tree/main/endpoints/getting-started) getting-started echo sample.
 * [PHP](https://github.com/GoogleCloudPlatform/php-docs-samples/blob/master/endpoints/getting-started) getting-started echo sample.
-* [Ruby](https://github.com/GoogleCloudPlatform/ruby-docs-samples/blob/master/endpoints/getting-started) getting-started echo sample.
-* [NodeJs](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/blob/master/endpoints/getting-started) getting-started echo sample.
+* [Ruby](https://github.com/GoogleCloudPlatform/ruby-docs-samples/tree/main/endpoints/getting-started) getting-started echo sample.
+* [NodeJs](https://github.com/GoogleCloudPlatform/nodejs-docs-samples/tree/main/endpoints/getting-started) getting-started echo sample.


### PR DESCRIPTION
The endpoints urls have moved to python-docs-samples/endpoints/getting-started

Also update other repos urls from `master` -> `main` branch.

Closes #43