### PR TITLE
use networking.k8s.io/v1 as v1beta is removed on GKE

### DIFF
--- a/getting-started/golang-deployment.yaml
+++ b/getting-started/golang-deployment.yaml
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: esp-echo
 spec:
-  backend:
-    serviceName: esp-echo # Name of the Service targeted by the Ingress
-    servicePort: 80 # Should match the port used by the Service
+  defaultBackend:
+    service:
+      name: esp-echo # Name of the Service targeted by the Ingress
+      port:
+        number: 80 # Should match the port used by the Service
 ---
 apiVersion: v1
 kind: Service

--- a/getting-started/grpc-deployment.yaml
+++ b/getting-started/grpc-deployment.yaml
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: grpc-hello
 spec:
-  backend:
-    serviceName: grpc-hello # Name of the Service targeted by the Ingress
-    servicePort: 80 # Should match the port used by the Service
+  defaultBackend:
+    service:
+      name: grpc-hello # Name of the Service targeted by the Ingress
+      port:
+        number: 80 # Should match the port used by the Service
 ---
 apiVersion: v1
 kind: Service

--- a/getting-started/java-deployment.yaml
+++ b/getting-started/java-deployment.yaml
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: esp-echo
 spec:
-  backend:
-    serviceName: esp-echo # Name of the Service targeted by the Ingress
-    servicePort: 80 # Should match the port used by the Service
+  defaultBackend:
+    service:
+      name: esp-echo # Name of the Service targeted by the Ingress
+      port:
+        number: 80 # Should match the port used by the Service
 ---
 apiVersion: v1
 kind: Service

--- a/getting-started/nodejs-deployment.yaml
+++ b/getting-started/nodejs-deployment.yaml
@@ -11,14 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: esp-echo
 spec:
-  backend:
-    serviceName: esp-echo # Name of the Service targeted by the Ingress
-    servicePort: 80 # Should match the port used by the Service
+  defaultBackend:
+    service:
+      name: esp-echo # Name of the Service targeted by the Ingress
+      port:
+        number: 80 # Should match the port used by the Service
 ---
 apiVersion: v1
 kind: Service

--- a/getting-started/php-deployment.yaml
+++ b/getting-started/php-deployment.yaml
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: esp-echo
 spec:
-  backend:
-    serviceName: esp-echo # Name of the Service targeted by the Ingress
-    servicePort: 80 # Should match the port used by the Service
+  defaultBackend:
+    service:
+      name: esp-echo # Name of the Service targeted by the Ingress
+      port:
+        number: 80 # Should match the port used by the Service
 ---
 apiVersion: v1
 kind: Service

--- a/getting-started/python-deployment.yaml
+++ b/getting-started/python-deployment.yaml
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: esp-echo
 spec:
-  backend:
-    serviceName: esp-echo # Name of the Service targeted by the Ingress
-    servicePort: 80 # Should match the port used by the Service
+  defaultBackend:
+    service:
+      name: esp-echo # Name of the Service targeted by the Ingress
+      port:
+        number: 80 # Should match the port used by the Service
 ---
 apiVersion: v1
 kind: Service

--- a/getting-started/ruby-deployment.yaml
+++ b/getting-started/ruby-deployment.yaml
@@ -12,14 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: esp-echo
 spec:
-  backend:
-    serviceName: esp-echo # Name of the Service targeted by the Ingress
-    servicePort: 80 # Should match the port used by the Service
+  defaultBackend:
+    service:
+      name: esp-echo # Name of the Service targeted by the Ingress
+      port:
+        number: 80 # Should match the port used by the Service
 ---
 apiVersion: v1
 kind: Service

--- a/gke/grpc-bookstore.yaml
+++ b/gke/grpc-bookstore.yaml
@@ -16,7 +16,7 @@
 # and the container for the Extensible Service Proxy (ESP) to
 # Google Kubernetes Engine (GKE).
 
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: esp-grpc-bookstore
@@ -28,9 +28,11 @@ spec:
   - hosts:
     - SERVICE_NAME
     secretName: esp-ssl
-  backend:
-    serviceName: esp-grpc-bookstore
-    servicePort: 443
+  defaultBackend:
+    service:
+      name: esp-grpc-bookstore
+      port:
+        number: 443
 ---
 apiVersion: cloud.google.com/v1
 kind: BackendConfig

--- a/k8s/esp_echo_gke_ingress.yaml
+++ b/k8s/esp_echo_gke_ingress.yaml
@@ -62,7 +62,7 @@ spec:
         ports:
           - containerPort: 8081
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: example
@@ -74,5 +74,7 @@ spec:
       # Note that the service will receive the entire URL with the prefix
       - path: /*
         backend:
-          serviceName: esp-echo
-          servicePort: 80
+          service:
+            name: esp-echo
+            port:
+              number: 80


### PR DESCRIPTION
From Kubernetes 1.22, Ingress/v1beta1 is removed. 